### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
 Use [`with`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith) to define any action parameters:
 ```yaml
 with:
-  tools-version: 2023.2-eap03
+  tool-version: 2023.2-eap03
 ```
 You can use GitHub Workflow editor to get a list of all supported inputs with descriptions. 
 |Name                     |Description                                                                                                                                                                               |Default           |


### PR DESCRIPTION
Fix the `tool-version` example in the `README.md`.

It is misspelled in the file, the correct is `tool-version` and was `tools-version` 