### PR TITLE
Pin actions by SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    groups:
+      github-actions:
+        applies-to: version-updates
+        update-types: ['minor', 'patch']
+      github-actions-majors:
+        applies-to: version-updates
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: 'monthly'

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
   using: composite
   steps:
   - name: Setup .NET
-    uses: actions/setup-dotnet@v5
+    uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
     with:
       dotnet-version: ${{ inputs.dotnet-version }}
   - name: Install ReSharper command line tools
@@ -139,7 +139,7 @@ runs:
       Invoke-Expression $command
   - name: Upload SARIF file
     if: inputs.format == 'Sarif'
-    uses: github/codeql-action/upload-sarif@v4
+    uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
     with:
       sarif_file: ${{ inputs.output }}
       category: resharper-inspectcode

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
   using: composite
   steps:
   - name: Setup .NET
-    uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+    uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
     with:
       dotnet-version: ${{ inputs.dotnet-version }}
   - name: Install ReSharper command line tools
@@ -139,7 +139,7 @@ runs:
       Invoke-Expression $command
   - name: Upload SARIF file
     if: inputs.format == 'Sarif'
-    uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
+    uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
     with:
       sarif_file: ${{ inputs.output }}
       category: resharper-inspectcode


### PR DESCRIPTION
Best practice for Github Actions is to pin actions by SHA. This can be enforced by github, and when it is, this action is unusable, because all dependent actions must be pinned as well.
This means the actions won't automatically use the latest version, so I also added dependabot.yml that will open PRs with a new version when it is released (1 grouped PR for minor updates, and individual PRs for major versions, monthly)